### PR TITLE
Bug Fix

### DIFF
--- a/firmware/user/MMA8452Q.c
+++ b/firmware/user/MMA8452Q.c
@@ -50,11 +50,11 @@ void ICACHE_FLASH_ATTR MMA8452Q_poll(accel_t* currentAccel)
     uint8_t data[7] = {0};
     brzo_i2c_read(data, sizeof(data), false);
 
-    brzo_i2c_end_transaction();
+    uint8_t completion_code = brzo_i2c_end_transaction();
 
-    if(brzo_i2c_get_error() != 0)
+    if(completion_code != 0)
     {
-        os_printf("Error : Input/Output error %02X\n", brzo_i2c_get_error());
+        os_printf("Error : Input/Output error %02X\n", completion_code);
     }
     else
     {

--- a/firmware/user/brzo_i2c.c
+++ b/firmware/user/brzo_i2c.c
@@ -1098,7 +1098,8 @@ void ICACHE_RAM_ATTR brzo_i2c_start_transaction(uint8_t slave_address, uint16_t 
 
 uint8_t ICACHE_RAM_ATTR brzo_i2c_end_transaction(void)
 {
-    // returns 0 if transaction completed successfully or error code encoded as follows
+    // returns 0 if transaction completed successfully or error code encoded as below
+    //    AND clears i2c_error for next transaction
     // Bit 0 (1) : Bus not free, i.e. either SDA or SCL is low
     // Bit 1 (2) : Not ACK ("NACK") by slave during write: Either the slave did not respond to the given slave address;
     //             or it did not ACK a byte transferred by the master.


### PR DESCRIPTION
Hi Adam, 

I got an Adafruit accelerometer which uses MMA8451Q (14bit) almost same as MMA8452Q. In process of getting it working (don't have OLED, so added printing to serial in demo), I noticed a small BUG. 

At line 53, `brzo_i2c_end_transaction();` will reset any error condition, so `brzo_i2c_get_error() ` used in line 55 will always be 0. 

So if I create error 2 by disconnecting SA0, I get no indication of a problem but get 0 values. Reconnecting starts up again

```X:-17 Y:0 Z:255
X:-17 Y:-1 Z:253
...
X:0 Y:0 Z:0
X:0 Y:0 Z:0
...
X:-18 Y:0 Z:253
X:-15 Y:0 Z:254
```

With the fix I'm getting this now:
```X:-15 Y:-3 Z:254
X:-15 Y:-2 Z:253
Error : Input/Output error 02
X:0 Y:0 Z:0
Error : Input/Output error 02
X:0 Y:0 Z:0
...
X:-15 Y:-2 Z:254
X:-15 Y:-1 Z:256
X:-14 Y:-3 Z:257
```