### PR TITLE
Allow button 0 to be used in all the modes

### DIFF
--- a/firmware/user/user_main.c
+++ b/firmware/user/user_main.c
@@ -545,7 +545,7 @@ void ICACHE_FLASH_ATTR swadgeModeButtonCallback(uint8_t state, int button, int d
             menuChangeBarProgress = 0;
         }
     }
-    else if(swadgeModeInit && NULL != swadgeModes[rtcMem.currentSwadgeMode]->fnButtonCallback)
+    if(swadgeModeInit && NULL != swadgeModes[rtcMem.currentSwadgeMode]->fnButtonCallback)
     {
         // Pass the button event to the mode
         swadgeModes[rtcMem.currentSwadgeMode]->fnButtonCallback(state, button, down);

--- a/firmware/user/user_main.c
+++ b/firmware/user/user_main.c
@@ -503,7 +503,7 @@ void ICACHE_FLASH_ATTR drawChangeMenuBar(void)
         menuChangeBarProgress += 10;
 
         // If it was held for long enough
-        if(menuChangeBarProgress == 131)
+        if(menuChangeBarProgress >= 131)
         {
             // Go back to the menu
             switchToSwadgeMode(0);


### PR DESCRIPTION
As long as button 0 is not held down to bring up the menu, it now can be used in the other modes as long as it is momentarily pressed. 