### PR TITLE
fixed bug in loadsettings where defaults fail to go to settings.configs

### DIFF
--- a/firmware/user/custom_commands.c
+++ b/firmware/user/custom_commands.c
@@ -185,6 +185,14 @@ void ICACHE_FLASH_ATTR LoadSettings(void)
     if( settings.SaveLoadKey == SAVE_LOAD_KEY )
     {
         os_printf("Settings found\r\n");
+        // load gConfigs from the settings
+        for( uint8_t i = 0; i < CONFIGURABLES; i++ )
+        {
+            if( gConfigs[i].val )
+            {
+                *(gConfigs[i].val) = settings.configs[i];
+            }
+        }
     }
     else
     {
@@ -198,23 +206,14 @@ void ICACHE_FLASH_ATTR LoadSettings(void)
         {
             if( gConfigs[i].val )
             {
-                settings.configs[i] = gConfigs[i].defaultVal;
+                *(gConfigs[i].val) = gConfigs[i].defaultVal;
             }
         }
         memset(settings.ttHighScores, 0, NUM_TT_HIGH_SCORES * sizeof(uint32_t));
         memset(settings.mzBestTimes, 0x0f, NUM_MZ_LEVELS * sizeof(uint32_t));
         settings.mzLastScore = 100000;
         settings.joustElo = 1000;
-        SaveSettings();
-    }
-
-    // load gConfigs from the settings
-    for( uint8_t i = 0; i < CONFIGURABLES; i++ )
-    {
-        if( gConfigs[i].val )
-        {
-            *gConfigs[i].val = settings.configs[i];
-        }
+        SaveSettings(); // updates settings.configs then saves
     }
 }
 


### PR DESCRIPTION
Hi Adam, 

I'm trying to used CC code with accelerometer input. It was surprising easy to do. The code is in embedddedcommon  and a bit in custom_commands.c. In doing so I found the defaults for the global CC variables were not being put in settings.config

As written at line 201, settings.configs is updated, but then at line 208, Savesettings();
destroys the values and at line 216 puts these in the global vars. 

Also please don't remove embeddedcommon from future commits. I'm adding my improvements to CC which I did ages ago, to produce a large variety of effects based. 

PS - when I compile your latest master after make clean, I'm getting lots of warnings for tiltrades.
       