### PR TITLE
Tweakcolorshake

### DIFF
--- a/firmware/user/modes/mode_roll.c
+++ b/firmware/user/modes/mode_roll.c
@@ -282,7 +282,7 @@ void ICACHE_FLASH_ATTR initializeConditionsForODE(uint8_t Method)
             roll.rhs_fun_ptr = &dnxdampedpendulum;
             roll.pendulumParameters = (pendParam)
             {
-                .damping = 0.9,
+                .damping = 0.01,
                 .lenPendulum = 1,
                 .gravity  = 9.81,
                 .force = 0


### PR DESCRIPTION
SHAKE charges up battery to full. 2 leds glow with colorwheel proportional to bar on battery. Once battery is more the 3/4 full the opposing lights rotate quickly and move quickly thru the rainbow. The longer shaking once completely full, the longer the display will last.

Changes friction on one ball, so more responsive, can spin it round more easily.