### PR TITLE
fixed bug in maze where auto mode reports incorrect time

### DIFF
--- a/firmware/user/modes/mode_mazerf.c
+++ b/firmware/user/modes/mode_mazerf.c
@@ -1515,6 +1515,7 @@ void ICACHE_FLASH_ATTR mzChangeState(mazeState_t newState)
             indSolutionStep = 0;
             indSolutionSubStep = 0;
             totalcyclestilldone = 0;
+            totalhitstilldone = 0;
             exitInd = UPPER_LEFT;
             break;
         case MZ_SCORES:


### PR DESCRIPTION
This probably would be noticed. If player waits 20 sec with ball touching a wall and then presses AUTO, 30 was added to adjusted time! 